### PR TITLE
Fix emoji tries to match over words

### DIFF
--- a/ParsedownExtended.php
+++ b/ParsedownExtended.php
@@ -552,7 +552,7 @@ class ParsedownExtended extends DynamicParent
             ':white_large_square:' => '⬜',
         ];
 
-        if (preg_match('/^(:)([^:]*?)(:)/', $excerpt['text'], $matches)) {
+        if (preg_match('/^(:)([^: ]*?)(:)/', $excerpt['text'], $matches)) {
             return [
                 'extent' => strlen($matches[0]),
                 'element' => [

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <h3 align="center">Parsedown Extended</h3>
 
   <p align="center">
-    <a href="https://benjaminhoegh.github.io/ParsedownExtended/configurations"><strong>Explore Documentation »</strong></a>
+    <a href="https://benjaminhoegh.github.io/ParsedownExtended/"><strong>Explore Documentation »</strong></a>
     <br>
     <br>
     <a href="https://github.com/BenjaminHoegh/ParsedownExtended/issues/new?template=bug_report.md">Report bug</a>

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Table of contents
 
 ## Getting started
 
-### Manuel
+### Manual
 Download the source code from the latest release
 You must include `parsedown.php` 1.8+
 Include `ParsedownExtended.php`


### PR DESCRIPTION
## Description
Fix emoji tries to match over words, by restricting character range to except space.

```php
echo $ParsedownExtended->text("* test: [link](https://google.com)");

# before: <li>test: [link](https://google.com)</li>
# after: <li>test: <a href="https://google.com/">link</a></li>
```

Also, I've fixed a typo and broken link in README.


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Contributing guidelines 
description: What steps have you taken to make sure your code follow the community guides?
options:

- [x] I have read the [CONTRIBUTING document](https://github.com/BenjaminHoegh/ParsedownExtended/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the [code style](https://github.com/BenjaminHoegh/ParsedownExtended/blob/main/.github/CONTRIBUTING.md#code-guidelines) of this project.


## Change to the documentation
description: What types of changes does your code introduce?
options:
  - [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

## Code of Conduct
By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/BenjaminHoegh/ParsedownExtended/blob/main/.github/CODE_OF_CONDUCT.md)

- [x] I agree to follow this project's Code of Conduct
