### PR TITLE
Fix a typo causing composer autoloader to fail.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   },
   "autoload": {
     "psr-0": {
-      "parsedownExtended": ""
+      "ParsedownExtended": ""
     }
   }
 }


### PR DESCRIPTION
## Description

I corrected a single-character capitalization typo that causes the autoloader to fail on any case-sensitive filesystem.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Contributing guidelines 

- [x] I have read the [CONTRIBUTING document](https://github.com/BenjaminHoegh/ParsedownExtended/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the [code style](https://github.com/BenjaminHoegh/ParsedownExtended/blob/main/.github/CONTRIBUTING.md#code-guidelines) of this project.

## Change to the documentation

  - [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

## Code of Conduct
By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/BenjaminHoegh/ParsedownExtended/blob/main/.github/CODE_OF_CONDUCT.md)

- [x] I agree to follow this project's Code of Conduct
