### PR TITLE
Add basic task list feature

### DIFF
--- a/src/Components/Inlines/TaskCheckbox.php
+++ b/src/Components/Inlines/TaskCheckbox.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace BenjaminHoegh\ParsedownExtended\Components\Inlines;
+
+use Erusev\Parsedown\AST\Handler;
+use Erusev\Parsedown\Components\Inline;
+use Erusev\Parsedown\Components\Inlines\WidthTrait;
+use Erusev\Parsedown\Html\Renderables\Element;
+use Erusev\Parsedown\Html\Renderables\Text;
+use Erusev\Parsedown\Parsedown;
+use Erusev\Parsedown\Parsing\Excerpt;
+use Erusev\Parsedown\State;
+
+final class TaskCheckbox implements Inline
+{
+    use WidthTrait;
+
+    /** @var bool */
+    private $checked;
+
+    private function __construct(bool $checked, int $width)
+    {
+        $this->checked = $checked;
+        $this->width = $width;
+    }
+
+    public static function build(Excerpt $Excerpt, State $State = null)
+    {
+        $text = $Excerpt->text();
+
+        if (preg_match('/^\[(x|X| )\](?=\s)/', $text, $matches)) {
+            $checked = strtolower($matches[1]) === 'x';
+            return new self($checked, strlen($matches[0]));
+        }
+
+        return null;
+    }
+
+    public function stateRenderable()
+    {
+        $attributes = [
+            'type' => 'checkbox',
+            'disabled' => 'disabled',
+        ];
+        if ($this->checked) {
+            $attributes['checked'] = 'checked';
+        }
+        return new Element('input', $attributes, []);
+    }
+
+    public function bestPlaintext()
+    {
+        return new Text($this->checked ? '[x]' : '[ ]');
+    }
+}

--- a/src/Features/TaskLists.php
+++ b/src/Features/TaskLists.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace BenjaminHoegh\ParsedownExtended\Features;
+
+use Erusev\Parsedown\Parsedown;
+use Erusev\Parsedown\State;
+use Erusev\Parsedown\StateBearer;
+use Erusev\Parsedown\Configurables\InlineTypes;
+
+use BenjaminHoegh\ParsedownExtended\Components\Inlines\TaskCheckbox;
+
+final class TaskLists implements StateBearer
+{
+    /** @var State */
+    private $State;
+
+    public function __construct(StateBearer $StateBearer = null)
+    {
+        $State = ($StateBearer ?? new State())->state();
+
+        $InlineTypes = $State->get(InlineTypes::class)
+            ->addingHighPrecedence('[', [TaskCheckbox::class]);
+
+        $this->State = $State
+            ->setting($InlineTypes);
+    }
+
+    public function state(): State
+    {
+        return $this->State;
+    }
+
+    public static function from(StateBearer $StateBearer)
+    {
+        return new self($StateBearer);
+    }
+}

--- a/src/ParsedownExtended.php
+++ b/src/ParsedownExtended.php
@@ -13,6 +13,7 @@ use BenjaminHoegh\ParsedownExtended\Features\Superscripts;
 use BenjaminHoegh\ParsedownExtended\Features\Subscripts;
 use BenjaminHoegh\ParsedownExtended\Features\Emojis;
 use BenjaminHoegh\ParsedownExtended\Features\Typographers;
+use BenjaminHoegh\ParsedownExtended\Features\TaskLists;
 
 final class ParsedownExtended implements StateBearer
 {
@@ -29,6 +30,7 @@ final class ParsedownExtended implements StateBearer
         $StateBearer = Subscripts::from($StateBearer);
         $StateBearer = Emojis::from($StateBearer);
         $StateBearer = Typographers::from($StateBearer);
+        $StateBearer = TaskLists::from($StateBearer);
 
         $this->State = $StateBearer->state();
     }


### PR DESCRIPTION
## Summary
- implement `TaskCheckbox` inline element for `[ ]` and `[x]`
- add new `TaskLists` feature hooking the inline element into Parsedown 2 state
- enable `TaskLists` feature in `ParsedownExtended`
