### PR TITLE
Add CriticMarkup support

### DIFF
--- a/src/Components/Inlines/CriticAddition.php
+++ b/src/Components/Inlines/CriticAddition.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace BenjaminHoegh\ParsedownExtended\Components\Inlines;
+
+use Erusev\Parsedown\AST\Handler;
+use Erusev\Parsedown\Components\Inline;
+use Erusev\Parsedown\Components\Inlines\WidthTrait;
+use Erusev\Parsedown\Html\Renderables\Element;
+use Erusev\Parsedown\Html\Renderables\Text;
+use Erusev\Parsedown\Parsedown;
+use Erusev\Parsedown\Parsing\Excerpt;
+use Erusev\Parsedown\State;
+
+final class CriticAddition implements Inline
+{
+    use WidthTrait;
+
+    /** @var string */
+    private $text;
+
+    private function __construct(string $text, int $width)
+    {
+        $this->text = $text;
+        $this->width = $width;
+    }
+
+    public static function build(Excerpt $Excerpt, State $State = null)
+    {
+        $text = $Excerpt->text();
+
+        if (preg_match('/^\{\+\+(?=\S)(.+?)(?<=\S)\+\+\}/s', $text, $matches)) {
+            return new self($matches[1], strlen($matches[0]));
+        }
+
+        return null;
+    }
+
+    public function text(): string
+    {
+        return $this->text;
+    }
+
+    public function stateRenderable()
+    {
+        return new Handler(function (State $State) {
+            return new Element('ins', [], $State->applyTo(Parsedown::line($this->text, $State)));
+        });
+    }
+
+    public function bestPlaintext()
+    {
+        return new Text($this->text);
+    }
+}

--- a/src/Components/Inlines/CriticComment.php
+++ b/src/Components/Inlines/CriticComment.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace BenjaminHoegh\ParsedownExtended\Components\Inlines;
+
+use Erusev\Parsedown\AST\Handler;
+use Erusev\Parsedown\Components\Inline;
+use Erusev\Parsedown\Components\Inlines\WidthTrait;
+use Erusev\Parsedown\Html\Renderables\Element;
+use Erusev\Parsedown\Html\Renderables\Text;
+use Erusev\Parsedown\Parsedown;
+use Erusev\Parsedown\Parsing\Excerpt;
+use Erusev\Parsedown\State;
+
+final class CriticComment implements Inline
+{
+    use WidthTrait;
+
+    /** @var string */
+    private $text;
+
+    private function __construct(string $text, int $width)
+    {
+        $this->text = $text;
+        $this->width = $width;
+    }
+
+    public static function build(Excerpt $Excerpt, State $State = null)
+    {
+        $text = $Excerpt->text();
+
+        if (preg_match('/^\{>>(?=\S)(.+?)(?<=\S)<<\}/s', $text, $matches)) {
+            return new self($matches[1], strlen($matches[0]));
+        }
+
+        return null;
+    }
+
+    public function stateRenderable()
+    {
+        return new Handler(function (State $State) {
+            return new Element('span', ['class' => 'critic comment'], $State->applyTo(Parsedown::line($this->text, $State)));
+        });
+    }
+
+    public function bestPlaintext()
+    {
+        return new Text($this->text);
+    }
+}

--- a/src/Components/Inlines/CriticDeletion.php
+++ b/src/Components/Inlines/CriticDeletion.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace BenjaminHoegh\ParsedownExtended\Components\Inlines;
+
+use Erusev\Parsedown\AST\Handler;
+use Erusev\Parsedown\Components\Inline;
+use Erusev\Parsedown\Components\Inlines\WidthTrait;
+use Erusev\Parsedown\Html\Renderables\Element;
+use Erusev\Parsedown\Html\Renderables\Text;
+use Erusev\Parsedown\Parsedown;
+use Erusev\Parsedown\Parsing\Excerpt;
+use Erusev\Parsedown\State;
+
+final class CriticDeletion implements Inline
+{
+    use WidthTrait;
+
+    /** @var string */
+    private $text;
+
+    private function __construct(string $text, int $width)
+    {
+        $this->text = $text;
+        $this->width = $width;
+    }
+
+    public static function build(Excerpt $Excerpt, State $State = null)
+    {
+        $text = $Excerpt->text();
+
+        if (preg_match('/^\{--(?=\S)(.+?)(?<=\S)--\}/s', $text, $matches)) {
+            return new self($matches[1], strlen($matches[0]));
+        }
+
+        return null;
+    }
+
+    public function text(): string
+    {
+        return $this->text;
+    }
+
+    public function stateRenderable()
+    {
+        return new Handler(function (State $State) {
+            return new Element('del', [], $State->applyTo(Parsedown::line($this->text, $State)));
+        });
+    }
+
+    public function bestPlaintext()
+    {
+        return new Text($this->text);
+    }
+}

--- a/src/Components/Inlines/CriticHighlight.php
+++ b/src/Components/Inlines/CriticHighlight.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace BenjaminHoegh\ParsedownExtended\Components\Inlines;
+
+use Erusev\Parsedown\AST\Handler;
+use Erusev\Parsedown\Components\Inline;
+use Erusev\Parsedown\Components\Inlines\WidthTrait;
+use Erusev\Parsedown\Html\Renderables\Element;
+use Erusev\Parsedown\Html\Renderables\Text;
+use Erusev\Parsedown\Parsedown;
+use Erusev\Parsedown\Parsing\Excerpt;
+use Erusev\Parsedown\State;
+
+final class CriticHighlight implements Inline
+{
+    use WidthTrait;
+
+    /** @var string */
+    private $text;
+
+    private function __construct(string $text, int $width)
+    {
+        $this->text = $text;
+        $this->width = $width;
+    }
+
+    public static function build(Excerpt $Excerpt, State $State = null)
+    {
+        $text = $Excerpt->text();
+
+        if (preg_match('/^\{==(?=\S)(.+?)(?<=\S)==\}/s', $text, $matches)) {
+            return new self($matches[1], strlen($matches[0]));
+        }
+
+        return null;
+    }
+
+    public function stateRenderable()
+    {
+        return new Handler(function (State $State) {
+            return new Element('mark', [], $State->applyTo(Parsedown::line($this->text, $State)));
+        });
+    }
+
+    public function bestPlaintext()
+    {
+        return new Text($this->text);
+    }
+}

--- a/src/Components/Inlines/CriticSubstitution.php
+++ b/src/Components/Inlines/CriticSubstitution.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace BenjaminHoegh\ParsedownExtended\Components\Inlines;
+
+use Erusev\Parsedown\AST\Handler;
+use Erusev\Parsedown\Components\Inline;
+use Erusev\Parsedown\Components\Inlines\WidthTrait;
+use Erusev\Parsedown\Html\Renderables\RawHtml;
+use Erusev\Parsedown\Html\Renderables\Text;
+use Erusev\Parsedown\Parsing\Excerpt;
+use Erusev\Parsedown\State;
+
+final class CriticSubstitution implements Inline
+{
+    use WidthTrait;
+
+    /** @var string */
+    private $delText;
+    /** @var string */
+    private $insText;
+
+    private function __construct(string $delText, string $insText, int $width)
+    {
+        $this->delText = $delText;
+        $this->insText = $insText;
+        $this->width = $width;
+    }
+
+    public static function build(Excerpt $Excerpt, State $State = null)
+    {
+        $text = $Excerpt->text();
+
+        if (preg_match('/^\{~~(?=\S)(.+?)(?<=\S)~>(?=\S)(.+?)(?<=\S)~~\}/s', $text, $matches)) {
+            return new self($matches[1], $matches[2], strlen($matches[0]));
+        }
+
+        return null;
+    }
+
+    public function stateRenderable()
+    {
+        return new Handler(function (State $State) {
+            return new RawHtml('<del>' . $this->delText . '</del><ins>' . $this->insText . '</ins>');
+        });
+    }
+
+    public function bestPlaintext()
+    {
+        return new Text($this->insText);
+    }
+}

--- a/src/Features/CriticMarkup.php
+++ b/src/Features/CriticMarkup.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace BenjaminHoegh\ParsedownExtended\Features;
+
+use Erusev\Parsedown\State;
+use Erusev\Parsedown\StateBearer;
+use Erusev\Parsedown\Configurables\InlineTypes;
+
+use BenjaminHoegh\ParsedownExtended\Components\Inlines\CriticAddition;
+use BenjaminHoegh\ParsedownExtended\Components\Inlines\CriticDeletion;
+use BenjaminHoegh\ParsedownExtended\Components\Inlines\CriticSubstitution;
+use BenjaminHoegh\ParsedownExtended\Components\Inlines\CriticComment;
+use BenjaminHoegh\ParsedownExtended\Components\Inlines\CriticHighlight;
+
+final class CriticMarkup implements StateBearer
+{
+    /** @var State */
+    private $State;
+
+    public function __construct(StateBearer $StateBearer = null)
+    {
+        $State = ($StateBearer ?? new State())->state();
+
+        $InlineTypes = $State->get(InlineTypes::class)
+            ->addingHighPrecedence('{', [
+                CriticAddition::class,
+                CriticDeletion::class,
+                CriticSubstitution::class,
+                CriticComment::class,
+                CriticHighlight::class,
+            ]);
+
+        $this->State = $State->setting($InlineTypes);
+    }
+
+    public function state(): State
+    {
+        return $this->State;
+    }
+
+    public static function from(StateBearer $StateBearer)
+    {
+        return new self($StateBearer);
+    }
+}

--- a/src/ParsedownExtended.php
+++ b/src/ParsedownExtended.php
@@ -15,6 +15,7 @@ use BenjaminHoegh\ParsedownExtended\Features\Typographers;
 use BenjaminHoegh\ParsedownExtended\Features\Smartypants;
 use BenjaminHoegh\ParsedownExtended\Features\TaskLists;
 use BenjaminHoegh\ParsedownExtended\Features\Alerts;
+use BenjaminHoegh\ParsedownExtended\Features\CriticMarkup;
 use BenjaminHoegh\ParsedownExtended\Features\HeadingPermalinks;
 use BenjaminHoegh\ParsedownExtended\Features\TableOfContents;
 
@@ -40,6 +41,7 @@ final class ParsedownExtended implements StateBearer
         $StateBearer = Smartypants::from($StateBearer);
         $StateBearer = TaskLists::from($StateBearer);
         $StateBearer = Alerts::from($StateBearer);
+        $StateBearer = CriticMarkup::from($StateBearer);
         $StateBearer = HeadingPermalinks::from($StateBearer);
         $StateBearer = TableOfContents::from($StateBearer);
 

--- a/tests/CriticMarkupTest.php
+++ b/tests/CriticMarkupTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use BenjaminHoegh\ParsedownExtended\ParsedownExtended;
+use PHPUnit\Framework\TestCase;
+
+class CriticMarkupTest extends TestCase
+{
+    protected ParsedownExtended $parsedownExtended;
+
+    protected function setUp(): void
+    {
+        $this->parsedownExtended = new ParsedownExtended();
+        $this->parsedownExtended->setSafeMode(true);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($this->parsedownExtended);
+    }
+
+    public function testAddition()
+    {
+        $markdown = 'This is a {++test++}.';
+        $expected = '<p>This is a <ins>test</ins>.</p>';
+        $this->assertEquals($expected, $this->parsedownExtended->text($markdown));
+    }
+
+    public function testDeletion()
+    {
+        $markdown = 'Delete {--this--} word.';
+        $expected = '<p>Delete <del>this</del> word.</p>';
+        $this->assertEquals($expected, $this->parsedownExtended->text($markdown));
+    }
+
+    public function testSubstitution()
+    {
+        $markdown = 'I like {~~apples~>oranges~~}.';
+        $expected = '<p>I like <del>apples</del><ins>oranges</ins>.</p>';
+        $this->assertEquals($expected, $this->parsedownExtended->text($markdown));
+    }
+
+    public function testComment()
+    {
+        $markdown = 'Do it. {>>now<<}';
+        $expected = '<p>Do it. <span class="critic comment">now</span></p>';
+        $this->assertEquals($expected, $this->parsedownExtended->text($markdown));
+    }
+
+    public function testHighlight()
+    {
+        $markdown = 'This is {==important==}.';
+        $expected = '<p>This is <mark>important</mark>.</p>';
+        $this->assertEquals($expected, $this->parsedownExtended->text($markdown));
+    }
+}


### PR DESCRIPTION
## Summary
- add CriticMarkup inline components and feature
- register CriticMarkup in ParsedownExtended
- implement unit tests for CriticMarkup

## Testing
- `phpunit --configuration phpunit.xml` *(fails: phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68504a0cbca0832194f042030845e8e7