### PR TITLE
Fix deprecations on null default parameters

### DIFF
--- a/src/Components/Blocks/Alert.php
+++ b/src/Components/Blocks/Alert.php
@@ -36,7 +36,7 @@ final class Alert implements ContinuableBlock
         $this->class = $class;
     }
 
-    public static function build(Context $Context, State $State, Block $Block = null)
+    public static function build(Context $Context, State $State, ?Block $Block = null)
     {
         $config = $State->get(AlertsConfig::class);
         $typesPattern = implode('|', array_map('strtoupper', $config->types()));

--- a/src/Components/Blocks/Diagram.php
+++ b/src/Components/Blocks/Diagram.php
@@ -27,7 +27,7 @@ final class Diagram implements ContinuableBlock
         $this->isComplete = $isComplete;
     }
 
-    public static function build(Context $Context, State $State, Block $Block = null)
+    public static function build(Context $Context, State $State, ?Block $Block = null)
     {
         $line = $Context->line()->text();
 

--- a/src/Components/Blocks/Math.php
+++ b/src/Components/Blocks/Math.php
@@ -45,7 +45,7 @@ final class Math implements ContinuableBlock
     public static function build(
         Context $Context,
         State $State,
-        Block $Block = null
+        ?Block $Block = null
     ) {
         $line = $Context->line()->text();
 

--- a/src/Components/Blocks/TocHeader.php
+++ b/src/Components/Blocks/TocHeader.php
@@ -39,7 +39,7 @@ final class TocHeader implements Block
         $this->attributes = $attributes;
     }
 
-    public static function build(Context $Context, State $State, Block $Block = null)
+    public static function build(Context $Context, State $State, ?Block $Block = null)
     {
         if ($Context->line()->indent() > 3) {
             return null;

--- a/src/Components/Blocks/TocSetextHeader.php
+++ b/src/Components/Blocks/TocSetextHeader.php
@@ -40,7 +40,7 @@ final class TocSetextHeader implements AcquisitioningBlock
         $this->attributes = $attributes;
     }
 
-    public static function build(Context $Context, State $State, Block $Block = null)
+    public static function build(Context $Context, State $State, ?Block $Block = null)
     {
         if (! isset($Block) || ! $Block instanceof \Erusev\Parsedown\Components\Blocks\Paragraph || $Context->precedingEmptyLines() > 0) {
             return null;

--- a/src/Components/Inlines/CriticAddition.php
+++ b/src/Components/Inlines/CriticAddition.php
@@ -24,7 +24,7 @@ final class CriticAddition implements Inline
         $this->width = $width;
     }
 
-    public static function build(Excerpt $Excerpt, State $State = null)
+    public static function build(Excerpt $Excerpt, ?State $State = null)
     {
         $text = $Excerpt->text();
 

--- a/src/Components/Inlines/CriticComment.php
+++ b/src/Components/Inlines/CriticComment.php
@@ -24,7 +24,7 @@ final class CriticComment implements Inline
         $this->width = $width;
     }
 
-    public static function build(Excerpt $Excerpt, State $State = null)
+    public static function build(Excerpt $Excerpt, ?State $State = null)
     {
         $text = $Excerpt->text();
 

--- a/src/Components/Inlines/CriticDeletion.php
+++ b/src/Components/Inlines/CriticDeletion.php
@@ -24,7 +24,7 @@ final class CriticDeletion implements Inline
         $this->width = $width;
     }
 
-    public static function build(Excerpt $Excerpt, State $State = null)
+    public static function build(Excerpt $Excerpt, ?State $State = null)
     {
         $text = $Excerpt->text();
 

--- a/src/Components/Inlines/CriticHighlight.php
+++ b/src/Components/Inlines/CriticHighlight.php
@@ -24,7 +24,7 @@ final class CriticHighlight implements Inline
         $this->width = $width;
     }
 
-    public static function build(Excerpt $Excerpt, State $State = null)
+    public static function build(Excerpt $Excerpt, ?State $State = null)
     {
         $text = $Excerpt->text();
 

--- a/src/Components/Inlines/CriticSubstitution.php
+++ b/src/Components/Inlines/CriticSubstitution.php
@@ -26,7 +26,7 @@ final class CriticSubstitution implements Inline
         $this->width = $width;
     }
 
-    public static function build(Excerpt $Excerpt, State $State = null)
+    public static function build(Excerpt $Excerpt, ?State $State = null)
     {
         $text = $Excerpt->text();
 

--- a/src/Components/Inlines/Emoji.php
+++ b/src/Components/Inlines/Emoji.php
@@ -248,7 +248,7 @@ final class Emoji implements Inline
      * @param State $State
      * @return static|null
      */
-    public static function build(Excerpt $Excerpt, State $State = null)
+    public static function build(Excerpt $Excerpt, ?State $State = null)
     {
         $text = $Excerpt->text();
 

--- a/src/Components/Inlines/Highlight.php
+++ b/src/Components/Inlines/Highlight.php
@@ -30,7 +30,7 @@ final class Highlight implements Inline
      * @param State $State
      * @return static|null
      */
-    public static function build(Excerpt $Excerpt, State $State = null)
+    public static function build(Excerpt $Excerpt, ?State $State = null)
     {
         $text = $Excerpt->text();
 

--- a/src/Components/Inlines/Keystroke.php
+++ b/src/Components/Inlines/Keystroke.php
@@ -30,7 +30,7 @@ final class Keystroke implements Inline
      * @param State $State
      * @return static|null
      */
-    public static function build(Excerpt $Excerpt, State $State = null)
+    public static function build(Excerpt $Excerpt, ?State $State = null)
     {
         $text = $Excerpt->text();
 

--- a/src/Components/Inlines/Math.php
+++ b/src/Components/Inlines/Math.php
@@ -26,7 +26,7 @@ final class Math implements Inline
      * @param State $State
      * @return static|null
      */
-    public static function build(Excerpt $Excerpt, State $State = null)
+    public static function build(Excerpt $Excerpt, ?State $State = null)
     {
         $State = $State ?: new State;
 

--- a/src/Components/Inlines/Smartypant.php
+++ b/src/Components/Inlines/Smartypant.php
@@ -25,7 +25,7 @@ final class Smartypant implements Inline
         $this->width = $width;
     }
 
-    public static function build(Excerpt $Excerpt, State $State = null)
+    public static function build(Excerpt $Excerpt, ?State $State = null)
     {
         $text = $Excerpt->text();
 

--- a/src/Components/Inlines/Subscript.php
+++ b/src/Components/Inlines/Subscript.php
@@ -30,7 +30,7 @@ final class Subscript implements Inline
      * @param State $State
      * @return static|null
      */
-    public static function build(Excerpt $Excerpt, State $State = null)
+    public static function build(Excerpt $Excerpt, ?State $State = null)
     {
         $text = $Excerpt->text();
 

--- a/src/Components/Inlines/Superscript.php
+++ b/src/Components/Inlines/Superscript.php
@@ -30,7 +30,7 @@ final class Superscript implements Inline
      * @param State $State
      * @return static|null
      */
-    public static function build(Excerpt $Excerpt, State $State = null)
+    public static function build(Excerpt $Excerpt, ?State $State = null)
     {
         $text = $Excerpt->text();
 

--- a/src/Components/Inlines/TaskCheckbox.php
+++ b/src/Components/Inlines/TaskCheckbox.php
@@ -24,7 +24,7 @@ final class TaskCheckbox implements Inline
         $this->width = $width;
     }
 
-    public static function build(Excerpt $Excerpt, State $State = null)
+    public static function build(Excerpt $Excerpt, ?State $State = null)
     {
         $text = $Excerpt->text();
 

--- a/src/Components/Inlines/Toc.php
+++ b/src/Components/Inlines/Toc.php
@@ -21,7 +21,7 @@ final class Toc implements Inline
         $this->width = $width;
     }
 
-    public static function build(Excerpt $Excerpt, State $State = null)
+    public static function build(Excerpt $Excerpt, ?State $State = null)
     {
         if (preg_match('/^\[toc\]/i', $Excerpt->text(), $m)) {
             return new self(strlen($m[0]));

--- a/src/Components/Inlines/Typographer.php
+++ b/src/Components/Inlines/Typographer.php
@@ -31,7 +31,7 @@ final class Typographer implements Inline
      * @param State $State
      * @return static|null
      */
-    public static function build(Excerpt $Excerpt, State $State = null)
+    public static function build(Excerpt $Excerpt, ?State $State = null)
     {
         $text = $Excerpt->text();
 

--- a/src/Features/Alerts.php
+++ b/src/Features/Alerts.php
@@ -14,7 +14,7 @@ final class Alerts implements StateBearer
     /** @var State */
     private $State;
 
-    public function __construct(StateBearer $StateBearer = null)
+    public function __construct(?StateBearer $StateBearer = null)
     {
         $State = ($StateBearer ?? new State())->state();
 

--- a/src/Features/CriticMarkup.php
+++ b/src/Features/CriticMarkup.php
@@ -17,7 +17,7 @@ final class CriticMarkup implements StateBearer
     /** @var State */
     private $State;
 
-    public function __construct(StateBearer $StateBearer = null)
+    public function __construct(?StateBearer $StateBearer = null)
     {
         $State = ($StateBearer ?? new State())->state();
 

--- a/src/Features/Diagrams.php
+++ b/src/Features/Diagrams.php
@@ -13,7 +13,7 @@ final class Diagrams implements StateBearer
     /** @var State */
     private $State;
 
-    public function __construct(StateBearer $StateBearer = null)
+    public function __construct(?StateBearer $StateBearer = null)
     {
         $State = ($StateBearer ?? new State)->state();
 

--- a/src/Features/Emojis.php
+++ b/src/Features/Emojis.php
@@ -14,7 +14,7 @@ final class Emojis implements StateBearer
     /** @var State */
     private $State;
 
-    public function __construct(StateBearer $StateBearer = null)
+    public function __construct(?StateBearer $StateBearer = null)
     {
         $State = ($StateBearer ?? new State)->state();
 

--- a/src/Features/HeadingPermalinks.php
+++ b/src/Features/HeadingPermalinks.php
@@ -12,7 +12,7 @@ final class HeadingPermalinks implements StateBearer
     /** @var State */
     private $State;
 
-    public function __construct(StateBearer $StateBearer = null)
+    public function __construct(?StateBearer $StateBearer = null)
     {
         $State = ($StateBearer ?? new State())->state();
 

--- a/src/Features/Highlights.php
+++ b/src/Features/Highlights.php
@@ -14,7 +14,7 @@ final class Highlights implements StateBearer
     /** @var State */
     private $State;
 
-    public function __construct(StateBearer $StateBearer = null)
+    public function __construct(?StateBearer $StateBearer = null)
     {
         $State = ($StateBearer ?? new State)->state();
 

--- a/src/Features/Keystrokes.php
+++ b/src/Features/Keystrokes.php
@@ -14,7 +14,7 @@ final class Keystrokes implements StateBearer
     /** @var State */
     private $State;
 
-    public function __construct(StateBearer $StateBearer = null)
+    public function __construct(?StateBearer $StateBearer = null)
     {
         $State = ($StateBearer ?? new State)->state();
 

--- a/src/Features/Maths.php
+++ b/src/Features/Maths.php
@@ -16,7 +16,7 @@ final class Maths implements StateBearer
     /** @var State */
     private $State;
 
-    public function __construct(StateBearer $StateBearer = null)
+    public function __construct(?StateBearer $StateBearer = null)
     {
         $State = ($StateBearer ?? new State)->state();
 

--- a/src/Features/Smartypants.php
+++ b/src/Features/Smartypants.php
@@ -13,7 +13,7 @@ final class Smartypants implements StateBearer
     /** @var State */
     private $State;
 
-    public function __construct(StateBearer $StateBearer = null)
+    public function __construct(?StateBearer $StateBearer = null)
     {
         $State = ($StateBearer ?? new State)->state();
 

--- a/src/Features/Subscripts.php
+++ b/src/Features/Subscripts.php
@@ -14,7 +14,7 @@ final class Subscripts implements StateBearer
     /** @var State */
     private $State;
 
-    public function __construct(StateBearer $StateBearer = null)
+    public function __construct(?StateBearer $StateBearer = null)
     {
         $State = ($StateBearer ?? new State)->state();
 

--- a/src/Features/Superscripts.php
+++ b/src/Features/Superscripts.php
@@ -14,7 +14,7 @@ final class Superscripts implements StateBearer
     /** @var State */
     private $State;
 
-    public function __construct(StateBearer $StateBearer = null)
+    public function __construct(?StateBearer $StateBearer = null)
     {
         $State = ($StateBearer ?? new State)->state();
 

--- a/src/Features/TableOfContents.php
+++ b/src/Features/TableOfContents.php
@@ -17,7 +17,7 @@ final class TableOfContents implements StateBearer
     /** @var State */
     private $State;
 
-    public function __construct(StateBearer $StateBearer = null)
+    public function __construct(?StateBearer $StateBearer = null)
     {
         $State = ($StateBearer ?? new State())->state();
 

--- a/src/Features/TaskLists.php
+++ b/src/Features/TaskLists.php
@@ -14,7 +14,7 @@ final class TaskLists implements StateBearer
     /** @var State */
     private $State;
 
-    public function __construct(StateBearer $StateBearer = null)
+    public function __construct(?StateBearer $StateBearer = null)
     {
         $State = ($StateBearer ?? new State())->state();
 

--- a/src/Features/Typographers.php
+++ b/src/Features/Typographers.php
@@ -14,7 +14,7 @@ final class Typographers implements StateBearer
     /** @var State */
     private $State;
 
-    public function __construct(StateBearer $StateBearer = null)
+    public function __construct(?StateBearer $StateBearer = null)
     {
         $State = ($StateBearer ?? new State)->state();
 

--- a/src/ParsedownExtended.php
+++ b/src/ParsedownExtended.php
@@ -25,7 +25,7 @@ final class ParsedownExtended implements StateBearer
     /** @var State */
     private $State;
 
-    public function __construct(StateBearer $StateBearer = null)
+    public function __construct(?StateBearer $StateBearer = null)
     {
 
         if ($StateBearer === null) {


### PR DESCRIPTION
## Summary
- declare nullable parameters with `?Type` hint

## Testing
- `php -v` *(fails: command not found)*
- `vendor/bin/phpunit --version` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68504d552d94832192ea4af99e3650da