### PR TITLE
Add nested ToC generation

### DIFF
--- a/src/Components/Inlines/Toc.php
+++ b/src/Components/Inlines/Toc.php
@@ -34,18 +34,48 @@ final class Toc implements Inline
         return new Handler(function (State $State) {
             $headings = $State->get(HeadingBook::class)->all();
 
-            $items = array_map(function ($h) use ($State) {
-                return new Element('li', [], [
-                    new Element(
-                        'a',
-                        ['href' => '#' . $h['slug']],
-                        $State->applyTo(Parsedown::line($h['text'], $State))
-                    )
-                ]);
-            }, $headings);
+            $root = [];
+            $stack = [];
+
+            foreach ($headings as $h) {
+                $node = ['heading' => $h, 'children' => []];
+
+                while (!empty($stack) && end($stack)['heading']['level'] >= $h['level']) {
+                    array_pop($stack);
+                }
+
+                if (empty($stack)) {
+                    $root[] = $node;
+                    $stack[] = &$root[array_key_last($root)];
+                } else {
+                    $parent = &$stack[array_key_last($stack)];
+                    $parent['children'][] = $node;
+                    $stack[] = &$parent['children'][array_key_last($parent['children'])];
+                }
+            }
+
+            $buildList = function (array $nodes) use (&$buildList, $State) {
+                $items = [];
+                foreach ($nodes as $n) {
+                    $contents = [
+                        new Element(
+                            'a',
+                            ['href' => '#' . $n['heading']['slug']],
+                            $State->applyTo(Parsedown::line($n['heading']['text'], $State))
+                        )
+                    ];
+
+                    if (!empty($n['children'])) {
+                        $contents[] = new Element('ul', [], $buildList($n['children']));
+                    }
+
+                    $items[] = new Element('li', [], $contents);
+                }
+                return $items;
+            };
 
             return new Element('nav', ['class' => 'toc'], [
-                new Element('ul', [], $items)
+                new Element('ul', [], $buildList($root))
             ]);
         });
     }


### PR DESCRIPTION
## Summary
- support nested list generation for `[toc]` inline tag

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851d95767d0832191cb330beed817eb