### PR TITLE
Fix: inlineTypographer no longer consumes entire line, allowing further Markdown parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ Thumbs.db
 .idea/
 qodana.yaml
 
+index.php

--- a/src/ParsedownExtended.php
+++ b/src/ParsedownExtended.php
@@ -978,26 +978,27 @@ class ParsedownExtended extends \ParsedownExtendedParentAlias
             $ellipses = $ellipsesKey === '...' ? '...' : html_entity_decode($ellipsesKey);
 
             $substitutions = [
-                '/\(c\)/i'      => '©',
-                '/\(r\)/i'      => '®',
-                '/\(tm\)/i'     => '™',
-                '/\(p\)/i'      => '¶',
-                '/\+-/i'        => '±',
-                '/\!\.{3,}/i'   => '!..',
-                '/\?\.{3,}/i'   => '?..',
-                '/\.{2,}/i'     => $ellipses,
+                '/^\(c\)/i'      => '©',
+                '/^\(r\)/i'      => '®',
+                '/^\(tm\)/i'     => '™',
+                '/^\(p\)/i'      => '¶',
+                '/^\+-/i'        => '±',
+                '/^!\.{3,}/i'    => '!..',
+                '/^\?\.{3,}/i'   => '?..',
+                '/^\.{2,}/i'     => $ellipses,
             ];
         }
 
-        $result = preg_replace(array_keys($substitutions), array_values($substitutions), $Excerpt['text'], -1, $count);
-
-        if ($count > 0 && $result !== $Excerpt['text']) {
-            return [
-                'extent' => strlen($Excerpt['text']),
-                'element' => [
-                    'text' => $result,
-                ],
-            ];
+        foreach ($substitutions as $pattern => $replacement) {
+            if (preg_match($pattern, $Excerpt['text'], $matches)) {
+                $match = $matches[0];
+                return [
+                    'extent' => strlen($match),
+                    'element' => [
+                        'text' => $replacement,
+                    ],
+                ];
+            }
         }
 
         return null;


### PR DESCRIPTION
Fix: inlineTypographer no longer consumes entire line, allowing further Markdown parsing

- Only matches typographic patterns at the start of the excerpt
- Returns correct extent for matched pattern
- Fixes bug where (c) **bold** would not render bold text