### PR TITLE
Fix empty heading IDs fallback to "heading"

### DIFF
--- a/src/ParsedownExtended.php
+++ b/src/ParsedownExtended.php
@@ -2755,6 +2755,11 @@ class ParsedownExtended extends \ParsedownExtendedParentAlias
         // Sanitize the text to make it a valid anchor ID
         $text = $this->sanitizeAnchor($text);
 
+        // Fall back to "heading" if sanitization produced an empty string
+        if ($text === '') {
+            $text = 'heading';
+        }
+
         // Ensure the generated anchor ID is unique
         return $this->uniquifyAnchorID($text);
     }

--- a/tests/HeadingsTest.php
+++ b/tests/HeadingsTest.php
@@ -237,6 +237,33 @@ class HeadingsTest extends TestCase
     }
 
     /**
+     * Empty headings should fall back to id="heading".
+     */
+    public function testEmptyHeadingProducesNoId()
+    {
+        $this->parsedownExtended->config()->set('headings.auto_anchors', true);
+
+        $markdown = '# ';
+        $actual = $this->parsedownExtended->text($markdown);
+
+        $this->assertStringContainsString(' id="heading"', $actual);
+    }
+
+    /**
+     * Headings consisting only of characters stripped during sanitization should fall back
+     * to id="heading".
+     */
+    public function testHeadingWithOnlyStrippedCharsProducesNoId()
+    {
+        $this->parsedownExtended->config()->set('headings.auto_anchors', true);
+
+        $markdown = '# ---';
+        $actual = $this->parsedownExtended->text($markdown);
+
+        $this->assertStringContainsString(' id="heading"', $actual);
+    }
+
+    /**
      * Test case for heading with custom logic using callback.
      */
     public function testHeadingUsingCallback()


### PR DESCRIPTION
Ensure that empty or sanitized headings default to "heading" for anchor ID generation, improving consistency in generated IDs.