### PR TITLE
Add allowlist/denylist configuration for inline attributes

### DIFF
--- a/src/ParsedownExtended.php
+++ b/src/ParsedownExtended.php
@@ -89,7 +89,7 @@ class ParsedownExtended extends \ParsedownExtendedParentAlias
                 'transliterate' => false,
                 'blacklist'     => [],
             ],
-            'special_attributes' => true,
+            'attributes' => true,
         ],
         'images' => true,
         'links' => [
@@ -146,6 +146,19 @@ class ParsedownExtended extends \ParsedownExtendedParentAlias
         ],
         'typographer' => true,
         'references'  => true,
+        'attributes' => [
+            'data_attributes' => false,
+            'denylist' => [
+                'classes'         => [],
+                'ids'             => [],
+                'data_attributes' => [],
+            ],
+            'allowlist' => [
+                'classes'         => [],
+                'ids'             => [],
+                'data_attributes' => [],
+            ],
+        ],
     ];
 
 
@@ -1680,7 +1693,7 @@ class ParsedownExtended extends \ParsedownExtendedParentAlias
      */
     protected function parseAttributeData($attributeString)
     {
-        if (!$this->config()->get('headings.special_attributes')) {
+        if (!$this->config()->get('headings.attributes')) {
             return [];
         }
 
@@ -1767,6 +1780,89 @@ class ParsedownExtended extends \ParsedownExtendedParentAlias
             }
 
             $attributes[$name] = $value;
+        }
+
+        return $this->filterSpecialAttributes($attributes);
+    }
+
+    /**
+     * Filters parsed special-attribute values against the configured allowlist and denylist.
+     *
+     * For each attribute type (classes, id, data-* attributes):
+     * - If an allowlist is non-empty, only values present in the list are kept.
+     * - Otherwise, values present in the denylist are removed.
+     * When both lists are populated the allowlist takes priority.
+     *
+     * @param array $attributes Parsed attribute map (e.g. ['class' => 'foo bar', 'id' => 'my-id']).
+     * @return array Filtered attribute map.
+     */
+    private function filterSpecialAttributes(array $attributes): array
+    {
+        $config = $this->config();
+
+        $allowlistClasses = $config->get('attributes.allowlist.classes');
+        $denylistClasses  = $config->get('attributes.denylist.classes');
+        $allowlistIds     = $config->get('attributes.allowlist.ids');
+        $denylistIds      = $config->get('attributes.denylist.ids');
+        $allowlistData    = $config->get('attributes.allowlist.data_attributes');
+        $denylistData     = $config->get('attributes.denylist.data_attributes');
+
+        // Filter class attribute
+        if (isset($attributes['class']) && $attributes['class'] !== '') {
+            $classes = explode(' ', $attributes['class']);
+
+            if ($allowlistClasses !== []) {
+                if (!in_array('*', $allowlistClasses, true)) {
+                    $classes = array_values(array_filter($classes, static function ($c) use ($allowlistClasses) {
+                        return in_array($c, $allowlistClasses, true);
+                    }));
+                }
+                // '*' in allowlist means allow all — no filtering needed
+            } elseif ($denylistClasses !== []) {
+                if (in_array('*', $denylistClasses, true)) {
+                    $classes = [];
+                } else {
+                    $classes = array_values(array_filter($classes, static function ($c) use ($denylistClasses) {
+                        return !in_array($c, $denylistClasses, true);
+                    }));
+                }
+            }
+
+            if ($classes === []) {
+                unset($attributes['class']);
+            } else {
+                $attributes['class'] = implode(' ', $classes);
+            }
+        }
+
+        // Filter id attribute
+        if (isset($attributes['id'])) {
+            $id = $attributes['id'];
+            if ($allowlistIds !== []) {
+                if (!in_array('*', $allowlistIds, true) && !in_array($id, $allowlistIds, true)) {
+                    unset($attributes['id']);
+                }
+            } elseif ($denylistIds !== []) {
+                if (in_array('*', $denylistIds, true) || in_array($id, $denylistIds, true)) {
+                    unset($attributes['id']);
+                }
+            }
+        }
+
+        // Filter data-* attributes
+        foreach (array_keys($attributes) as $name) {
+            if (strpos($name, 'data-') !== 0) {
+                continue;
+            }
+            if ($allowlistData !== []) {
+                if (!in_array('*', $allowlistData, true) && !in_array($name, $allowlistData, true)) {
+                    unset($attributes[$name]);
+                }
+            } elseif ($denylistData !== []) {
+                if (in_array('*', $denylistData, true) || in_array($name, $denylistData, true)) {
+                    unset($attributes[$name]);
+                }
+            }
         }
 
         return $attributes;
@@ -2431,12 +2527,18 @@ class ParsedownExtended extends \ParsedownExtendedParentAlias
             }
 
             // Generate an anchor ID for the header element
-            // If an ID attribute is not set, use the text to create the ID
-            $id = $Block['element']['attributes']['id'] ?? $text;
-            $id = $this->createAnchorID($id);
+            // Preserve any other special attributes (class, data-*) already parsed by the parent
+            $existingAttributes = $Block['element']['attributes'] ?? [];
+            $explicitId = $existingAttributes['id'] ?? null;
+            $id = $this->createAnchorID($explicitId ?? $text);
 
-            // Set the 'id' attribute for the header element
-            $Block['element']['attributes'] = ['id' => $id];
+            if ($id !== null) {
+                $existingAttributes['id'] = $id;
+            } elseif ($explicitId === null) {
+                // Auto-anchors are off and no explicit id was set via special attributes
+                unset($existingAttributes['id']);
+            }
+            $Block['element']['attributes'] = $existingAttributes;
 
             // Check if the heading level should be included in the Table of Contents (TOC)
             // Also ensure we skip adding it to TOC if it is disabled in the config
@@ -2488,12 +2590,18 @@ class ParsedownExtended extends \ParsedownExtendedParentAlias
             }
 
             // Generate an anchor ID for the header element
-            // If an ID attribute is not set, use the text to create the ID
-            $id = $Block['element']['attributes']['id'] ?? $text;
-            $id = $this->createAnchorID($id);
+            // Preserve any other special attributes (class, data-*) already parsed by the parent
+            $existingAttributes = $Block['element']['attributes'] ?? [];
+            $explicitId = $existingAttributes['id'] ?? null;
+            $id = $this->createAnchorID($explicitId ?? $text);
 
-            // Set the 'id' attribute for the header element
-            $Block['element']['attributes'] = ['id' => $id];
+            if ($id !== null) {
+                $existingAttributes['id'] = $id;
+            } elseif ($explicitId === null) {
+                // Auto-anchors are off and no explicit id was set via special attributes
+                unset($existingAttributes['id']);
+            }
+            $Block['element']['attributes'] = $existingAttributes;
 
             // Check if the heading level should be included in the Table of Contents (TOC)
             // Also ensure we skip adding it to TOC if it is disabled in the config
@@ -3519,8 +3627,36 @@ class ParsedownExtended extends \ParsedownExtendedParentAlias
                 /* -------------------- helpers --------------------------- */
                 private function normalisePath(string $p): string
                 {
+                    $p = $this->resolveDeprecatedAlias($p);
                     if (!isset($this->schema[$p]) && isset($this->schema[$p . '.enabled'])) {
                         return $p . '.enabled';
+                    }
+                    return $p;
+                }
+
+                private function resolveDeprecatedAlias(string $p): string
+                {
+                    static $aliases = [
+                        'headings.special_attributes'                        => 'headings.attributes',
+                        'special_attributes'                                 => 'attributes',
+                        'special_attributes.enabled'                         => 'attributes.enabled',
+                        'special_attributes.allowlist'                       => 'attributes.allowlist',
+                        'special_attributes.denylist'                        => 'attributes.denylist',
+                        'special_attributes.allowlist.classes'               => 'attributes.allowlist.classes',
+                        'special_attributes.allowlist.ids'                   => 'attributes.allowlist.ids',
+                        'special_attributes.allowlist.data_attributes'       => 'attributes.allowlist.data_attributes',
+                        'special_attributes.denylist.classes'                => 'attributes.denylist.classes',
+                        'special_attributes.denylist.ids'                    => 'attributes.denylist.ids',
+                        'special_attributes.denylist.data_attributes'        => 'attributes.denylist.data_attributes',
+                    ];
+
+                    if (isset($aliases[$p])) {
+                        $new = $aliases[$p];
+                        @trigger_error(
+                            "ParsedownExtended: config path \"{$p}\" is deprecated, use \"{$new}\" instead.",
+                            E_USER_DEPRECATED
+                        );
+                        return $new;
                     }
                     return $p;
                 }
@@ -3769,7 +3905,7 @@ class ParsedownExtended extends \ParsedownExtendedParentAlias
      */
     private function applyInlineAttributeData(array $Inline, string $remainder): array
     {
-        if (!$this->config()->get('headings.special_attributes')) {
+        if (!$this->config()->get('headings.attributes')) {
             return $Inline;
         }
 
@@ -3778,6 +3914,9 @@ class ParsedownExtended extends \ParsedownExtendedParentAlias
         }
 
         $attributes = $this->parseAttributeData($matches[1]);
+
+        $Inline['extent'] += strlen($matches[0]);
+
         if ($attributes === []) {
             return $Inline;
         }
@@ -3800,8 +3939,6 @@ class ParsedownExtended extends \ParsedownExtendedParentAlias
             $Inline['element']['attributes'][$normalizedName] = $value;
         }
 
-        $Inline['extent'] += strlen($matches[0]);
-
         return $Inline;
     }
 
@@ -3817,6 +3954,10 @@ class ParsedownExtended extends \ParsedownExtendedParentAlias
             return true;
         }
 
-        return strpos($name, 'data-') === 0;
+        if (strpos($name, 'data-') === 0) {
+            return $this->config()->get('attributes.data_attributes');
+        }
+
+        return false;
     }
 }

--- a/tests/AttributesTest.php
+++ b/tests/AttributesTest.php
@@ -1,0 +1,285 @@
+<?php
+
+use BenjaminHoegh\ParsedownExtended\ParsedownExtended;
+use PHPUnit\Framework\TestCase;
+
+class AttributesTest extends TestCase
+{
+    private ParsedownExtended $parsedownExtended;
+
+    protected function setUp(): void
+    {
+        $this->parsedownExtended = new ParsedownExtended();
+        $this->parsedownExtended->setSafeMode(true);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($this->parsedownExtended);
+    }
+
+    // -------------------------------------------------------------------------
+    // Basic inline attribute syntax
+    // -------------------------------------------------------------------------
+
+    public function testInlineClassOnLink()
+    {
+        $markdown = '[link](http://example.com){.my-class}';
+        $actual = $this->parsedownExtended->line($markdown);
+        $this->assertStringContainsString('class="my-class"', $actual);
+    }
+
+    public function testInlineIdOnLink()
+    {
+        $markdown = '[link](http://example.com){#my-id}';
+        $actual = $this->parsedownExtended->line($markdown);
+        $this->assertStringContainsString('id="my-id"', $actual);
+    }
+
+    public function testInlineDataAttributeOnLink()
+    {
+        $this->parsedownExtended->config()->set('attributes.data_attributes', true);
+
+        $markdown = '[link](http://example.com){[data-foo="bar"]}';
+        $actual = $this->parsedownExtended->line($markdown);
+        $this->assertStringContainsString('data-foo="bar"', $actual);
+    }
+
+    public function testInlineMultipleAttributesOnLink()
+    {
+        $this->parsedownExtended->config()->set('attributes.data_attributes', true);
+
+        $markdown = '[link](http://example.com){.highlight #nav [data-section="main"]}';
+        $actual = $this->parsedownExtended->line($markdown);
+        $this->assertStringContainsString('class="highlight"', $actual);
+        $this->assertStringContainsString('id="nav"', $actual);
+        $this->assertStringContainsString('data-section="main"', $actual);
+    }
+
+    public function testInlineClassOnImage()
+    {
+        $markdown = '![alt](http://example.com/img.png){.thumb}';
+        $actual = $this->parsedownExtended->line($markdown);
+        $this->assertStringContainsString('class="thumb"', $actual);
+    }
+
+    // -------------------------------------------------------------------------
+    // Denylist
+    // -------------------------------------------------------------------------
+
+    public function testDenylistBlocksClass()
+    {
+        $this->parsedownExtended->config()->set('attributes.denylist.classes', ['secret']);
+
+        $markdown = '[link](http://example.com){.secret .visible}';
+        $actual = $this->parsedownExtended->line($markdown);
+        $this->assertStringNotContainsString('secret', $actual);
+        $this->assertStringContainsString('class="visible"', $actual);
+    }
+
+    public function testDenylistBlocksId()
+    {
+        $this->parsedownExtended->config()->set('attributes.denylist.ids', ['forbidden']);
+
+        $markdown = '[link](http://example.com){#forbidden}';
+        $actual = $this->parsedownExtended->line($markdown);
+        $this->assertStringNotContainsString('id=', $actual);
+    }
+
+    public function testDenylistBlocksDataAttribute()
+    {
+        $this->parsedownExtended->config()->set('attributes.data_attributes', true);
+        $this->parsedownExtended->config()->set('attributes.denylist.data_attributes', ['data-secret']);
+
+        $markdown = '[link](http://example.com){[data-secret="yes"] [data-public="yes"]}';
+        $actual = $this->parsedownExtended->line($markdown);
+        $this->assertStringNotContainsString('data-secret', $actual);
+        $this->assertStringContainsString('data-public="yes"', $actual);
+    }
+
+    public function testDenylistWildcardBlocksAllClasses()
+    {
+        $this->parsedownExtended->config()->set('attributes.denylist.classes', ['*']);
+
+        $markdown = '[link](http://example.com){.foo .bar}';
+        $actual = $this->parsedownExtended->line($markdown);
+        $this->assertStringNotContainsString('class=', $actual);
+    }
+
+    public function testDenylistWildcardBlocksAllIds()
+    {
+        $this->parsedownExtended->config()->set('attributes.denylist.ids', ['*']);
+
+        $markdown = '[link](http://example.com){#any-id}';
+        $actual = $this->parsedownExtended->line($markdown);
+        $this->assertStringNotContainsString('id=', $actual);
+    }
+
+    public function testDenylistWildcardBlocksAllDataAttributes()
+    {
+        $this->parsedownExtended->config()->set('attributes.data_attributes', true);
+        $this->parsedownExtended->config()->set('attributes.denylist.data_attributes', ['*']);
+
+        $markdown = '[link](http://example.com){[data-foo="yes"] [data-bar="true"]}';
+        $actual = $this->parsedownExtended->line($markdown);
+        $this->assertStringNotContainsString('data-foo', $actual);
+        $this->assertStringNotContainsString('data-bar', $actual);
+    }
+
+    // -------------------------------------------------------------------------
+    // Allowlist
+    // -------------------------------------------------------------------------
+
+    public function testAllowlistPermitsOnlyListedClasses()
+    {
+        $this->parsedownExtended->config()->set('attributes.allowlist.classes', ['highlight', 'note']);
+
+        $markdown = '[link](http://example.com){.highlight .danger}';
+        $actual = $this->parsedownExtended->line($markdown);
+        $this->assertStringContainsString('class="highlight"', $actual);
+        $this->assertStringNotContainsString('danger', $actual);
+    }
+
+    public function testAllowlistPermitsOnlyListedIds()
+    {
+        $this->parsedownExtended->config()->set('attributes.allowlist.ids', ['nav', 'header']);
+
+        $markdown = '[link](http://example.com){#other}';
+        $actual = $this->parsedownExtended->line($markdown);
+        $this->assertStringNotContainsString('id=', $actual);
+    }
+
+    public function testAllowlistPermitsOnlyListedDataAttributes()
+    {
+        $this->parsedownExtended->config()->set('attributes.data_attributes', true);
+        $this->parsedownExtended->config()->set('attributes.allowlist.data_attributes', ['data-allowed']);
+
+        $markdown = '[link](http://example.com){[data-allowed="yes"] [data-blocked="no"]}';
+        $actual = $this->parsedownExtended->line($markdown);
+        $this->assertStringContainsString('data-allowed="yes"', $actual);
+        $this->assertStringNotContainsString('data-blocked', $actual);
+    }
+
+    public function testAllowlistWildcardAllowsAllClasses()
+    {
+        $this->parsedownExtended->config()->set('attributes.allowlist.classes', ['*']);
+
+        $markdown = '[link](http://example.com){.foo .bar}';
+        $actual = $this->parsedownExtended->line($markdown);
+        $this->assertStringContainsString('class="foo bar"', $actual);
+    }
+
+    public function testAllowlistTakesPriorityOverDenylist()
+    {
+        $this->parsedownExtended->config()->set('attributes.allowlist.classes', ['highlight']);
+        $this->parsedownExtended->config()->set('attributes.denylist.classes', ['highlight']);
+
+        $markdown = '[link](http://example.com){.highlight .other}';
+        $actual = $this->parsedownExtended->line($markdown);
+        $this->assertStringContainsString('class="highlight"', $actual);
+        $this->assertStringNotContainsString('other', $actual);
+    }
+
+    // -------------------------------------------------------------------------
+    // Security: only class, id, and data-* are permitted; data-* off by default
+    // -------------------------------------------------------------------------
+
+    public function testDataAttributesDisabledByDefault()
+    {
+        $markdown = '[link](http://example.com){[data-foo="bar"]}';
+        $actual = $this->parsedownExtended->line($markdown);
+        $this->assertStringNotContainsString('data-foo', $actual);
+    }
+
+    public function testDataAttributesCanBeEnabled()
+    {
+        $this->parsedownExtended->config()->set('attributes.data_attributes', true);
+
+        $markdown = '[link](http://example.com){[data-foo="bar"]}';
+        $actual = $this->parsedownExtended->line($markdown);
+        $this->assertStringContainsString('data-foo="bar"', $actual);
+    }
+
+    public function testEventHandlerAttributeIsBlocked()
+    {
+        $markdown = '[link](http://example.com){[onclick="alert(1)"]}';
+        $actual = $this->parsedownExtended->line($markdown);
+        $this->assertStringNotContainsString('onclick', $actual);
+    }
+
+    public function testStyleAttributeIsBlocked()
+    {
+        $markdown = '[link](http://example.com){[style="color:red"]}';
+        $actual = $this->parsedownExtended->line($markdown);
+        $this->assertStringNotContainsString('style=', $actual);
+    }
+
+    public function testSrcAttributeIsBlocked()
+    {
+        $markdown = '[link](http://example.com){[src="http://evil.com"]}';
+        $actual = $this->parsedownExtended->line($markdown);
+        $this->assertStringNotContainsString('src=', $actual);
+    }
+
+    public function testArbitraryHtmlAttributeIsBlocked()
+    {
+        $markdown = '[link](http://example.com){[tabindex="0"] [accesskey="x"]}';
+        $actual = $this->parsedownExtended->line($markdown);
+        $this->assertStringNotContainsString('tabindex', $actual);
+        $this->assertStringNotContainsString('accesskey', $actual);
+    }
+
+    public function testOnlyClassAndIdPermittedByDefault()
+    {
+        // data-* is off by default; only class and id should pass through
+        $markdown = '[link](http://example.com){.safe #safe-id [data-ok="yes"] [onclick="bad"] [style="bad"]}';
+        $actual = $this->parsedownExtended->line($markdown);
+        $this->assertStringContainsString('class="safe"', $actual);
+        $this->assertStringContainsString('id="safe-id"', $actual);
+        $this->assertStringNotContainsString('data-ok', $actual);
+        $this->assertStringNotContainsString('onclick', $actual);
+        $this->assertStringNotContainsString('style=', $actual);
+    }
+
+    public function testOnlyClassIdAndDataPrefixArePermittedWhenEnabled()
+    {
+        $this->parsedownExtended->config()->set('attributes.data_attributes', true);
+
+        $markdown = '[link](http://example.com){.safe #safe-id [data-ok="yes"] [onclick="bad"] [style="bad"]}';
+        $actual = $this->parsedownExtended->line($markdown);
+        $this->assertStringContainsString('class="safe"', $actual);
+        $this->assertStringContainsString('id="safe-id"', $actual);
+        $this->assertStringContainsString('data-ok="yes"', $actual);
+        $this->assertStringNotContainsString('onclick', $actual);
+        $this->assertStringNotContainsString('style=', $actual);
+    }
+
+    public function testMixedCaseEventHandlerIsBlocked()
+    {
+        // Attribute names are lowercased before the safety check
+        $markdown = '[link](http://example.com){[ONCLICK="alert(1)"]}';
+        $actual = $this->parsedownExtended->line($markdown);
+        $this->assertStringNotContainsString('onclick', $actual);
+        $this->assertStringNotContainsString('ONCLICK', $actual);
+    }
+
+
+    public function testFilteredAttributesBracesSuppressed()
+    {
+        // When all attributes are filtered out the {…} syntax must not appear in output
+        $this->parsedownExtended->config()->set('attributes.denylist.classes', ['*']);
+
+        $markdown = '[link](http://example.com){.foo}';
+        $actual = $this->parsedownExtended->line($markdown);
+        $this->assertStringNotContainsString('{', $actual);
+    }
+
+    public function testAttributesDisabledLeavesNoTrailingBraces()
+    {
+        $this->parsedownExtended->config()->set('headings.attributes', false);
+
+        $markdown = '[link](http://example.com){.foo}';
+        $actual = $this->parsedownExtended->line($markdown);
+        $this->assertStringNotContainsString('class=', $actual);
+    }
+}

--- a/tests/HeadingsTest.php
+++ b/tests/HeadingsTest.php
@@ -231,4 +231,253 @@ class HeadingsTest extends TestCase
         $actual = $this->parsedownExtended->text($markdown);
         $this->assertEquals($expected, $actual);
     }
+
+    /**
+     * Test attributes: basic class and id.
+     */
+    public function testAttributesClassAndId()
+    {
+        $this->parsedownExtended->config()->set('headings.auto_anchors', false);
+
+        $markdown = '# Heading {.my-class #my-id}';
+        $expected = '<h1 class="my-class" id="my-id">Heading</h1>';
+        $actual = $this->parsedownExtended->text($markdown);
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test attributes: denylist blocks a specific class.
+     */
+    public function testAttributesDenylistClass()
+    {
+        $this->parsedownExtended->config()->set('headings.auto_anchors', false);
+        $this->parsedownExtended->config()->set('attributes.denylist.classes', ['secret', 'internal']);
+
+        $markdown = '# Heading {.visible .secret}';
+        $expected = '<h1 class="visible">Heading</h1>';
+        $actual = $this->parsedownExtended->text($markdown);
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test attributes: denylist removes all classes when all are denied.
+     */
+    public function testAttributesDenylistAllClasses()
+    {
+        $this->parsedownExtended->config()->set('headings.auto_anchors', false);
+        $this->parsedownExtended->config()->set('attributes.denylist.classes', ['secret']);
+
+        $markdown = '# Heading {.secret}';
+        $expected = '<h1>Heading</h1>';
+        $actual = $this->parsedownExtended->text($markdown);
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test attributes: denylist blocks a specific id.
+     */
+    public function testAttributesDenylistId()
+    {
+        $this->parsedownExtended->config()->set('headings.auto_anchors', false);
+        $this->parsedownExtended->config()->set('attributes.denylist.ids', ['forbidden-id']);
+
+        $markdown = '# Heading {#forbidden-id}';
+        $expected = '<h1>Heading</h1>';
+        $actual = $this->parsedownExtended->text($markdown);
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test attributes: denylist blocks a specific data-* attribute (inline element).
+     */
+    public function testAttributesDenylistDataAttribute()
+    {
+        $this->parsedownExtended->config()->set('attributes.data_attributes', true);
+        $this->parsedownExtended->config()->set('attributes.denylist.data_attributes', ['data-secret']);
+
+        $markdown = '[link](http://example.com){[data-secret="yes"] [data-visible="true"]}';
+        $actual = $this->parsedownExtended->text($markdown);
+        $this->assertStringNotContainsString('data-secret', $actual);
+        $this->assertStringContainsString('data-visible="true"', $actual);
+    }
+
+    /**
+     * Test attributes: allowlist permits only specific classes.
+     */
+    public function testAttributesAllowlistClass()
+    {
+        $this->parsedownExtended->config()->set('headings.auto_anchors', false);
+        $this->parsedownExtended->config()->set('attributes.allowlist.classes', ['highlight', 'note']);
+
+        $markdown = '# Heading {.highlight .danger}';
+        $expected = '<h1 class="highlight">Heading</h1>';
+        $actual = $this->parsedownExtended->text($markdown);
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test attributes: allowlist with wildcard allows all classes.
+     */
+    public function testAttributesAllowlistClassWildcard()
+    {
+        $this->parsedownExtended->config()->set('headings.auto_anchors', false);
+        $this->parsedownExtended->config()->set('attributes.allowlist.classes', ['*']);
+
+        $markdown = '# Heading {.anything .whatever}';
+        $expected = '<h1 class="anything whatever">Heading</h1>';
+        $actual = $this->parsedownExtended->text($markdown);
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test attributes: denylist with wildcard blocks all classes.
+     */
+    public function testAttributesDenylistClassWildcard()
+    {
+        $this->parsedownExtended->config()->set('headings.auto_anchors', false);
+        $this->parsedownExtended->config()->set('attributes.denylist.classes', ['*']);
+
+        $markdown = '# Heading {.anything .whatever}';
+        $expected = '<h1>Heading</h1>';
+        $actual = $this->parsedownExtended->text($markdown);
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test attributes: allowlist permits only specific ids.
+     */
+    public function testAttributesAllowlistId()
+    {
+        $this->parsedownExtended->config()->set('headings.auto_anchors', false);
+        $this->parsedownExtended->config()->set('attributes.allowlist.ids', ['allowed-id']);
+
+        $markdown = '# Heading {#other-id}';
+        $expected = '<h1>Heading</h1>';
+        $actual = $this->parsedownExtended->text($markdown);
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test attributes: denylist with wildcard blocks all ids.
+     */
+    public function testAttributesDenylistIdWildcard()
+    {
+        $this->parsedownExtended->config()->set('headings.auto_anchors', false);
+        $this->parsedownExtended->config()->set('attributes.denylist.ids', ['*']);
+
+        $markdown = '# Heading {#any-id}';
+        $expected = '<h1>Heading</h1>';
+        $actual = $this->parsedownExtended->text($markdown);
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test attributes: allowlist permits only specific data-* attributes (inline element).
+     */
+    public function testAttributesAllowlistDataAttribute()
+    {
+        $this->parsedownExtended->config()->set('attributes.data_attributes', true);
+        $this->parsedownExtended->config()->set('attributes.allowlist.data_attributes', ['data-allowed']);
+
+        $markdown = '[link](http://example.com){[data-allowed="yes"] [data-blocked="no"]}';
+        $actual = $this->parsedownExtended->text($markdown);
+        $this->assertStringContainsString('data-allowed="yes"', $actual);
+        $this->assertStringNotContainsString('data-blocked', $actual);
+    }
+
+    /**
+     * Test attributes: denylist with wildcard blocks all data-* attributes (inline element).
+     */
+    public function testAttributesDenylistDataAttributeWildcard()
+    {
+        $this->parsedownExtended->config()->set('attributes.data_attributes', true);
+        $this->parsedownExtended->config()->set('attributes.denylist.data_attributes', ['*']);
+
+        $markdown = '[link](http://example.com){[data-foo="yes"] [data-bar="true"]}';
+        $actual = $this->parsedownExtended->text($markdown);
+        $this->assertStringNotContainsString('data-foo', $actual);
+        $this->assertStringNotContainsString('data-bar', $actual);
+    }
+
+    /**
+     * Test attributes: allowlist takes priority over denylist.
+     */
+    public function testAttributesAllowlistTakesPriorityOverDenylist()
+    {
+        $this->parsedownExtended->config()->set('headings.auto_anchors', false);
+        $this->parsedownExtended->config()->set('attributes.allowlist.classes', ['highlight']);
+        $this->parsedownExtended->config()->set('attributes.denylist.classes', ['highlight']);
+
+        $markdown = '# Heading {.highlight .other}';
+        $expected = '<h1 class="highlight">Heading</h1>';
+        $actual = $this->parsedownExtended->text($markdown);
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test that attributes can be disabled entirely.
+     */
+    public function testAttributesCanBeDisabled()
+    {
+        $this->parsedownExtended->config()->set('headings.auto_anchors', false);
+        $this->parsedownExtended->config()->set('headings.attributes', false);
+
+        // When disabled, ParsedownExtra still strips the {.my-class} syntax from the text
+        $markdown = '# Heading {.my-class}';
+        $expected = '<h1>Heading</h1>';
+        $actual = $this->parsedownExtended->text($markdown);
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test that old "special_attributes.*" config paths still work and emit a deprecation warning.
+     */
+    public function testSpecialAttributesDeprecatedAlias()
+    {
+        $deprecations = [];
+        set_error_handler(function ($errno, $errstr) use (&$deprecations) {
+            $deprecations[] = $errstr;
+            return true;
+        }, E_USER_DEPRECATED);
+
+        $this->parsedownExtended->config()->set('special_attributes.denylist.classes', ['secret']);
+
+        restore_error_handler();
+
+        $this->assertCount(1, $deprecations);
+        $this->assertStringContainsString('special_attributes.denylist.classes', $deprecations[0]);
+        $this->assertStringContainsString('attributes.denylist.classes', $deprecations[0]);
+
+        // Verify the value was actually applied via the new path
+        $markdown = '# Heading {.secret .visible}';
+        $actual = $this->parsedownExtended->text($markdown);
+        $this->assertStringNotContainsString('secret', $actual);
+        $this->assertStringContainsString('visible', $actual);
+    }
+
+    /**
+     * Test that old "headings.special_attributes" config path still works and emits a deprecation warning.
+     */
+    public function testHeadingsSpecialAttributesDeprecatedAlias()
+    {
+        $deprecations = [];
+        set_error_handler(function ($errno, $errstr) use (&$deprecations) {
+            $deprecations[] = $errstr;
+            return true;
+        }, E_USER_DEPRECATED);
+
+        $this->parsedownExtended->config()->set('headings.auto_anchors', false);
+        $this->parsedownExtended->config()->set('headings.special_attributes', false);
+
+        restore_error_handler();
+
+        $this->assertCount(1, $deprecations);
+        $this->assertStringContainsString('headings.special_attributes', $deprecations[0]);
+        $this->assertStringContainsString('headings.attributes', $deprecations[0]);
+
+        $markdown = '# Heading {.my-class}';
+        $expected = '<h1>Heading</h1>';
+        $actual = $this->parsedownExtended->text($markdown);
+        $this->assertEquals($expected, $actual);
+    }
 }

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -38,6 +38,8 @@ class ImageTest extends TestCase
 
     public function testImageWithTrailingAttributes()
     {
+        $this->parsedownExtended->config()->set('attributes.data_attributes', true);
+
         $markdown = '![some image](image.png){.shadow.center [data-zoom] #hero}';
         $expectedHtml = '<p><img src="image.png" alt="some image" class="shadow center" data-zoom="data-zoom" id="hero" /></p>';
         $result = $this->parsedownExtended->text($markdown);
@@ -56,6 +58,8 @@ class ImageTest extends TestCase
 
     public function testImageDisallowsSensitiveTrailingAttributes()
     {
+        $this->parsedownExtended->config()->set('attributes.data_attributes', true);
+
         $markdown = '![some image](image.png){[src=evil.png] [style=color:red] .safe #ok [data-track=1]}';
         $result = $this->parsedownExtended->text($markdown);
 

--- a/tests/LinksTest.php
+++ b/tests/LinksTest.php
@@ -44,6 +44,8 @@ class LinksTest extends TestCase
 
     public function testInlineLinkWithTrailingAttributes()
     {
+        $this->parsedownExtended->config()->set('attributes.data_attributes', true);
+
         $markdown = '[Link](link.png){.shadow.center [data-zoom] #hero}';
         $expectedHtml = '<p><a href="link.png" class="shadow center" data-zoom="data-zoom" id="hero">Link</a></p>';
         $html = $this->parsedownExtended->text($markdown);
@@ -53,6 +55,8 @@ class LinksTest extends TestCase
 
     public function testInlineLinkDisallowsSensitiveTrailingAttributes()
     {
+        $this->parsedownExtended->config()->set('attributes.data_attributes', true);
+
         $markdown = '[External](https://www.google.com){[href=https://evil.com] [target=_self] [rel=noopener] [style=color:red] .safe #ok [data-track=1]}';
         $html = $this->parsedownExtended->text($markdown);
 


### PR DESCRIPTION
Introduce a new `attributes` configuration section to filter classes, ids, and data-* attributes on supported elements. This includes allowlist and denylist functionality, with wildcards and backward compatibility for deprecated paths. Comprehensive tests ensure proper functionality and security measures.