### PR TITLE
2.2.1

### DIFF
--- a/src/ParsedownExtended.php
+++ b/src/ParsedownExtended.php
@@ -16,7 +16,7 @@ class_alias(class_exists('ParsedownExtra') ? 'ParsedownExtra' : 'Parsedown', 'Pa
 // @psalm-suppress UndefinedClass
 class ParsedownExtended extends \ParsedownExtendedParentAlias
 {
-    public const VERSION = '2.2.0';
+    public const VERSION = '2.2.1';
     public const VERSION_PARSEDOWN_REQUIRED = '1.8.0';
     public const VERSION_PARSEDOWN_EXTRA_REQUIRED = '0.9.0';
     public const MIN_PHP_VERSION = '7.4';
@@ -1846,8 +1846,14 @@ class ParsedownExtended extends \ParsedownExtendedParentAlias
      */
     protected function blockReference($Line)
     {
+        $config = $this->config();
+
+        if (!$config->get('footnotes') && preg_match('/^\[\^.+?\]:/', $Line['text'])) {
+            return null;
+        }
+
         // Check if references are enabled
-        if ($this->config()->get('references')) {
+        if ($config->get('references')) {
             return parent::blockReference($Line); // Delegate to parent class
         }
 
@@ -2354,13 +2360,17 @@ class ParsedownExtended extends \ParsedownExtendedParentAlias
 
             // Generate an anchor ID for the header element
             // If an ID attribute is not set, use the text to create the ID
-            $id = $Block['element']['attributes']['id'] ?? $text;
-            $id = $this->createAnchorID($id);
+            $anchorId = $Block['element']['attributes']['id'] ?? $text;
+            $anchorId = $this->createAnchorID($anchorId);
 
             // Set the 'id' attribute only when an anchor ID is generated
-            if ($id !== null) {
-                $Block['element']['attributes']['id'] = $id;
+            if (is_string($anchorId) && $anchorId !== '') {
+                $Block['element']['attributes']['id'] = $anchorId;
+            } elseif (isset($Block['element']['attributes']['id']) && $Block['element']['attributes']['id'] === '') {
+                unset($Block['element']['attributes']['id']);
             }
+
+            $id = $Block['element']['attributes']['id'] ?? null;
 
             // Check if the heading level should be included in the Table of Contents (TOC)
             // Also ensure we skip adding it to TOC if it is disabled in the config
@@ -2413,13 +2423,17 @@ class ParsedownExtended extends \ParsedownExtendedParentAlias
 
             // Generate an anchor ID for the header element
             // If an ID attribute is not set, use the text to create the ID
-            $id = $Block['element']['attributes']['id'] ?? $text;
-            $id = $this->createAnchorID($id);
+            $anchorId = $Block['element']['attributes']['id'] ?? $text;
+            $anchorId = $this->createAnchorID($anchorId);
 
             // Set the 'id' attribute only when an anchor ID is generated
-            if ($id !== null) {
-                $Block['element']['attributes']['id'] = $id;
+            if (is_string($anchorId) && $anchorId !== '') {
+                $Block['element']['attributes']['id'] = $anchorId;
+            } elseif (isset($Block['element']['attributes']['id']) && $Block['element']['attributes']['id'] === '') {
+                unset($Block['element']['attributes']['id']);
             }
+
+            $id = $Block['element']['attributes']['id'] ?? null;
 
             // Check if the heading level should be included in the Table of Contents (TOC)
             // Also ensure we skip adding it to TOC if it is disabled in the config
@@ -2675,7 +2689,7 @@ class ParsedownExtended extends \ParsedownExtendedParentAlias
 
         switch (strtolower($type_return)) {
             case 'string':
-                return $this->contentsListString ? $this->body($this->contentsListString) : '';
+                return $this->contentsListString ? parent::text($this->contentsListString) : '';
             case 'json':
                 $json = json_encode($this->contentsListArray);
                 return is_string($json) ? $json : '[]';

--- a/tests/DiagramsTest.php
+++ b/tests/DiagramsTest.php
@@ -67,4 +67,17 @@ class DiagramsTest extends TestCase
 
         $this->assertEquals($expectedHtml, $result);
     }
+
+    public function testDisableChartjsDiagramTypeForChartjsFenceAlias()
+    {
+        $this->parsedownExtended->config()->set('diagrams', true);
+        $this->parsedownExtended->config()->set('diagrams.chartjs', false);
+
+        $markdown = "```chartjs\n{\"type\":\"line\",\"data\":{}}\n```";
+        $expectedHtml = "<pre><code class=\"language-chartjs\">{\"type\":\"line\",\"data\":{}}</code></pre>";
+
+        $result = $this->parsedownExtended->text($markdown);
+
+        $this->assertEquals($expectedHtml, $result);
+    }
 }

--- a/tests/FootnotesTest.php
+++ b/tests/FootnotesTest.php
@@ -42,6 +42,34 @@ class FootnotesTest extends TestCase
         $this->assertStringNotContainsString('href="#fn:', $html);
     }
 
+    public function testFootnotesDisabledDoesNotTreatFootnoteDefinitionsAsReferences()
+    {
+        $this->parsedownExtended->config()->set('footnotes', false);
+        $this->parsedownExtended->config()->set('references', true);
+
+        $markdown = "Text[^1]\n\n[^1]: Note.";
+        $expected = "<p>Text[^1]</p>\n<p>[^1]: Note.</p>";
+
+        $html = $this->parsedownExtended->text($markdown);
+
+        $this->assertEquals($expected, $html);
+    }
+
+    public function testFootnoteConfigChangesAffectLaterParses()
+    {
+        $markdown = "Text[^1]\n\n[^1]: Note.";
+        $disabledExpected = "<p>Text[^1]</p>\n<p>[^1]: Note.</p>";
+
+        $this->parsedownExtended->config()->set('footnotes', false);
+        $this->assertEquals($disabledExpected, $this->parsedownExtended->text($markdown));
+
+        $this->parsedownExtended->config()->set('footnotes', true);
+        $this->assertStringContainsString('<sup', $this->parsedownExtended->text($markdown));
+
+        $this->parsedownExtended->config()->set('footnotes', false);
+        $this->assertEquals($disabledExpected, $this->parsedownExtended->text($markdown));
+    }
+
     public function testMultipleFootnotes()
     {
         $this->parsedownExtended->config()->set('footnotes', true);

--- a/tests/HeadingsTest.php
+++ b/tests/HeadingsTest.php
@@ -89,6 +89,27 @@ class HeadingsTest extends TestCase
     }
 
     /**
+     * Duplicate heading counters should reset between parses on the same instance.
+     */
+    public function testHeadingAnchorRegisterResetsBetweenParses()
+    {
+        $this->parsedownExtended->config()->set('headings.auto_anchors', true);
+
+        $firstMarkdown = <<<MARKDOWN
+            # Heading
+            # Heading
+            MARKDOWN;
+
+        $firstExpected = <<<HTML
+            <h1 id="heading">Heading</h1>
+            <h1 id="heading-1">Heading</h1>
+            HTML;
+
+        $this->assertEquals($firstExpected, $this->parsedownExtended->text($firstMarkdown));
+        $this->assertEquals('<h1 id="heading">Heading</h1>', $this->parsedownExtended->text('# Heading'));
+    }
+
+    /**
      * Test case for heading with custom anchor.
      */
     public function testHeadingWithCustomAnchor()
@@ -276,6 +297,20 @@ class HeadingsTest extends TestCase
         $markdown = '# Heading 1';
         $expected = '<h1 id="custom-anchor">Heading 1</h1>';
         $actual = $this->parsedownExtended->text($markdown);
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testHeadingUsingCallbackReturningEmptyStringDoesNotRenderEmptyId()
+    {
+        $this->parsedownExtended->config()->set('headings.auto_anchors', true);
+        $this->parsedownExtended->setCreateAnchorIDCallback(function () {
+            return '';
+        });
+
+        $markdown = '# Heading 1';
+        $expected = '<h1>Heading 1</h1>';
+        $actual = $this->parsedownExtended->text($markdown);
+
         $this->assertEquals($expected, $actual);
     }
 }

--- a/tests/ReferencesTest.php
+++ b/tests/ReferencesTest.php
@@ -38,6 +38,23 @@ class ReferencesTest extends TestCase
         $this->assertStringContainsString('[link text][ref]', $html);
     }
 
+    public function testReferenceConfigChangesAffectLaterParses()
+    {
+        $markdown = "[link text][ref]\n\n[ref]: https://example.com";
+
+        $this->parsedownExtended->config()->set('references', false);
+        $this->assertStringContainsString('<p>[link text][ref]</p>', $this->parsedownExtended->text($markdown));
+
+        $this->parsedownExtended->config()->set('references', true);
+        $this->assertStringContainsString(
+            '<a href="https://example.com">link text</a>',
+            $this->parsedownExtended->text($markdown)
+        );
+
+        $this->parsedownExtended->config()->set('references', false);
+        $this->assertStringContainsString('<p>[link text][ref]</p>', $this->parsedownExtended->text($markdown));
+    }
+
     public function testReferenceWithTitle()
     {
         $this->parsedownExtended->config()->set('references', true);

--- a/tests/TocTest.php
+++ b/tests/TocTest.php
@@ -227,4 +227,67 @@ class TocTest extends TestCase
 
         $this->assertSame('[]', $actual);
     }
+
+    public function testContentsListStringDoesNotClearContentsListState()
+    {
+        $this->parsedownExtended->config()->set('headings.auto_anchors', true);
+
+        $this->parsedownExtended->body("# One\n## Two");
+
+        $expectedJson = '[{"text":"One","id":"one","level":"h1"},{"text":"Two","id":"two","level":"h2"}]';
+        $expectedString = <<<HTML
+            <ul>
+            <li><a href="#one">One</a><ul>
+            <li><a href="#two">Two</a></li>
+            </ul>
+            </li>
+            </ul>
+            HTML;
+
+        $this->assertSame($expectedJson, $this->parsedownExtended->contentsList('json'));
+        $this->assertSame($expectedString, $this->parsedownExtended->contentsList());
+        $this->assertSame($expectedJson, $this->parsedownExtended->contentsList('json'));
+    }
+
+    public function testContentsListIsAvailableAfterParsingWithTocTag()
+    {
+        $this->parsedownExtended->config()->set('headings.auto_anchors', true);
+
+        $html = $this->parsedownExtended->text("[TOC]\n# One\n## Two");
+
+        $expectedJson = '[{"text":"One","id":"one","level":"h1"},{"text":"Two","id":"two","level":"h2"}]';
+        $expectedString = <<<HTML
+            <ul>
+            <li><a href="#one">One</a><ul>
+            <li><a href="#two">Two</a></li>
+            </ul>
+            </li>
+            </ul>
+            HTML;
+
+        $this->assertStringContainsString('<div id="toc"><ul>', $html);
+        $this->assertSame($expectedJson, $this->parsedownExtended->contentsList('json'));
+        $this->assertSame($expectedString, $this->parsedownExtended->contentsList());
+    }
+
+    public function testContentsListResetsBetweenRepeatedParses()
+    {
+        $this->parsedownExtended->config()->set('headings.auto_anchors', true);
+
+        $this->parsedownExtended->text("# First\n# First");
+        $this->assertSame(
+            '[{"text":"First","id":"first","level":"h1"},{"text":"First","id":"first-1","level":"h1"}]',
+            $this->parsedownExtended->contentsList('json')
+        );
+
+        $this->parsedownExtended->text('# Second');
+        $this->assertSame(
+            '[{"text":"Second","id":"second","level":"h1"}]',
+            $this->parsedownExtended->contentsList('json')
+        );
+
+        $this->parsedownExtended->text('No headings here.');
+        $this->assertSame('[]', $this->parsedownExtended->contentsList('json'));
+        $this->assertSame('', $this->parsedownExtended->contentsList());
+    }
 }

--- a/tests/TypographerTest.php
+++ b/tests/TypographerTest.php
@@ -52,4 +52,17 @@ class TypographerTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
+    public function testTypographerDoesNotConsumeRemainingInlineMarkdown(): void
+    {
+        $this->parsedownExtended->config()->set('typographer', true);
+
+        $markdown = '(c) **bold** and [link](https://example.com)';
+
+        $result = $this->parsedownExtended->text($markdown);
+
+        $this->assertStringContainsString('© <strong>bold</strong> and <a href="https://example.com"', $result);
+        $this->assertStringContainsString('>link</a>', $result);
+        $this->assertStringNotContainsString('**bold**', $result);
+    }
+
 }


### PR DESCRIPTION
## Fixed

- Avoid rendering empty `id` attributes on headings, including when a custom anchor callback returns an empty string.
- Keep duplicate heading anchor state isolated between repeated parses on the same parser instance.
- Keep table-of-contents state isolated between repeated parses.
- Preserve `contentsList()` data after parsing documents with `[TOC]`.
- Preserve `contentsList()` data after calling `contentsList('string')`.
- Keep disabled footnote definitions from being treated as reference definitions.
- Confirm Mermaid and Chart.js diagram feature flags are honored, including the `chartjs` fence alias.
- Confirm typographer substitutions consume only the matched token and leave later inline Markdown available for parsing.
- Confirm reference and footnote runtime config changes affect later parses.
